### PR TITLE
Update package.clj dep versions to prevent errors using lein

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,7 +13,7 @@
 #+BEGIN_SRC clojure
   {:deps {
           orgmode {:git/url "https://github.com/bnbeckwith/orgmode"
-                   :sha "5b83296a645af8011ed282b86de1d5995a9914f8"}
+                   :sha "52c153649ebff4c90f50be32458d413ef416aeb7"}
           }}
 #+END_SRC
 
@@ -28,7 +28,7 @@
 In your favorite terminal, launch a repl with
 
 #+begin_src bash
-clojure -Adev
+  clojure -Adev
 #+end_src
 
 #+BEGIN_SRC clojure
@@ -55,3 +55,4 @@ clojure -Adev
 
 - Benjamin Beckwith
 - David Pham
+- Kevin Pavao

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src"]
  :deps
  {hiccup {:mvn/version "1.0.5"}
-  org.apache.commons/commons-lang3 {:mvn/version "3.10"}}
+  org.apache.commons/commons-lang3 {:mvn/version "3.11"}}
  :aliases
  {:dev {:extra-paths ["test"]
         :extra-deps {midje {:mvn/version "1.9.9"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/bnbeckwith/orgmode"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [hiccup "1.0.4"]
-                 [org.apache.commons/commons-lang3 "3.1"]]
-  :profiles {:dev {:dependencies [[midje "1.6.3"]]}})
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [hiccup "1.0.5"]
+                 [org.apache.commons/commons-lang3 "3.11"]]
+  :profiles {:dev {:dependencies [[midje "1.9.9"]]}})

--- a/src/orgmode/block.clj
+++ b/src/orgmode/block.clj
@@ -327,5 +327,5 @@
 (defn parse-lines
   "Parse coll as org-mode formatting"
   [coll]
-  (let [root (clojure.zip/xml-zip {:level 0})]
+  (let [root (zip/xml-zip {:level 0})]
     (trampoline next-line coll root)))

--- a/src/orgmode/core.clj
+++ b/src/orgmode/core.clj
@@ -18,7 +18,7 @@
 (defn parse-lines
   "Parse coll as a sequence of orgmode lines"
   [coll]
-  (orgmode.block/parse-lines coll))
+  (block/parse-lines coll))
 
 (defn parse-str
   "Split a string and parse it"
@@ -32,16 +32,16 @@
     (parse-lines (line-seq r))))
 
 ;; ### Generated formatted text
-(defn convert 
-  "Convert the structure to html 
+(defn convert
+  "Convert the structure to html
 
   The user can supply a function for handling source blocks."
   ([r]
-     (html/org-to-html r))
+   (html/org-to-html r))
   ([r f]
-     (binding [orgmode.html/*user-src-fn* f]
-       (convert r))))
-  
+   (binding [html/*user-src-fn* f]
+     (convert r))))
+
 
 ;; ### Utilities
 ;;
@@ -51,7 +51,7 @@
 (defn zip
   "Returns a zipper from org elements (from orgmode/parse)"
   [root]
-  (clojure.zip/xml-zip root))
+  (zip/xml-zip root))
 
 (defn getall
   "Returns all nodes from root satisifying f"

--- a/src/orgmode/html.clj
+++ b/src/orgmode/html.clj
@@ -1,4 +1,4 @@
-;; ## HTML output 
+;; ## HTML output
 ;;
 ;; Functions to facilitate HTML output
 
@@ -14,23 +14,23 @@
 (def img-suffix-re
   #"(?i)(png|bmp|jpg|jpeg)$")
 
-(def ^:dynamic *user-src-fn* 
+(def ^:dynamic *user-src-fn*
   "User-defined function to use for SRC blocks of code. This
   function will be called with the SRC block map passed in."
   (fn [x] nil))
 
-(defn squish-seq 
+(defn squish-seq
   "For any consecutive sequences, merge them into one."
   [s]
   (letfn [(concat-seq ([] [])
             ([x y]
-               (vec 
+               (vec
                 (if (seq? y)
                   (concat x (squish-seq y))
                   (into x [y])))))]
     (reduce concat-seq [] s)))
-                   
-(defn maybe-img 
+
+(defn maybe-img
   ([url] (maybe-img url url))
   ([url alt]
      (if (re-find img-suffix-re url)
@@ -61,7 +61,7 @@
     [:pre
      [:code
       (StringEscapeUtils/escapeHtml4 (t/join "\n" (:content x)))]]))
-  
+
 (defmethod blockprocess :default [x]
   (into [(:block x)] (:content x)))
 
@@ -91,7 +91,7 @@
         rows (if hdr? (next (filter #(not= :tline %) rows)) rows)]
     (into tbl
           (for [row rows]
-            (into [:tr] 
+            (into [:tr]
                   (map (fn [x] [:td (hiccupify x)]) row))))))
 
 (defmethod hiccupify :block [x]
@@ -107,7 +107,7 @@
    (:id x)])
 
 (defmethod hiccupify :footnote [x]
-  (into [:a.footnote-def 
+  (into [:a.footnote-def
          {:id (:id x)
           :href (str "#" (:id x))}]
    (hiccupify (:content x))))

--- a/src/orgmode/inline.clj
+++ b/src/orgmode/inline.clj
@@ -147,7 +147,7 @@
       (make-elem ts-inactive-re ts-inactive-create)
       (make-elem (fmt-re "\\*") (fmt-create :bold))
       (make-elem (fmt-re "/")   (fmt-create :italic))
-      (make-elem (fmt-re "\\+")   (fmt-create :strike-through))
+      (make-elem (fmt-re "\\+") (fmt-create :strike-through))
       (make-elem (fmt-re "_")   (fmt-create :underline))
       (make-elem (fmt-re "=")   (fmt-create :verbatim))
       (make-elem (fmt-re "~")   (fmt-create :code))))

--- a/src/orgmode/util.clj
+++ b/src/orgmode/util.clj
@@ -9,10 +9,9 @@
 (defn org-to-html-links [z]
   (if (zip/end? z)
     (zip/root z)
-    (recur (zip/next 
+    (recur (zip/next
             (let [n (zip/node z)]
               (if (and (map? n)
                          (= :link (:type n)))
                 (zip/edit z fix-link)
                 z))))))
-            


### PR DESCRIPTION
Hey! I found your library while searching for things to use in a personal project of mine. I am trying to learn Clojure and wanted to mess around with your library locally, but when I cloned it I was getting some errors using `lein`. I saw the previous pull request had updated `deps.edn` and that the versions in `project.clj` did not match. When I updated them I was no longer getting any errors when using `lein`. I verified that all the tests still pass using `lein midgje`.

One thing I am not sure of is how the version of the package changes for the `lein` bit in the README. I will update that if I need to.

Thanks for the great library!

**Summary of changes:**
- Update all dependency versions
- Match dependency versions in `deps.edn` and `project.clj`
- Minor whitespace and function call cleanup